### PR TITLE
fix: resolve Sass deprecation warnings in SCSS styles

### DIFF
--- a/src/assets/styles/components/_line-chart.scss
+++ b/src/assets/styles/components/_line-chart.scss
@@ -11,13 +11,13 @@
 
   &--color {
     $color-type: (
-      blue: var(--blue-500),
-      purple: var(--purple-500),
-      yellow: var(--yellow-500),
-      pink: var(--pink-500),
-      green: var(--brand-500),
-      grey: var(--grey-500),
-      red: var(--red-500)
+      'blue': var(--blue-500),
+      'purple': var(--purple-500),
+      'yellow': var(--yellow-500),
+      'pink': var(--pink-500),
+      'green': var(--brand-500),
+      'grey': var(--grey-500),
+      'red': var(--red-500)
     );
 
     @each $type, $color in $color-type {
@@ -36,13 +36,13 @@
     margin-right: var(--size-8);
 
     $color-type: (
-      blue: var(--blue-500),
-      purple: var(--purple-500),
-      yellow: var(--yellow-500),
-      pink: var(--pink-500),
-      green: var(--brand-500),
-      grey: var(--grey-500),
-      red: var(--red-500)
+      'blue': var(--blue-500),
+      'purple': var(--purple-500),
+      'yellow': var(--yellow-500),
+      'pink': var(--pink-500),
+      'green': var(--brand-500),
+      'grey': var(--grey-500),
+      'red': var(--red-500)
     );
 
     @each $type, $color in $color-type {

--- a/src/assets/styles/components/_status.scss
+++ b/src/assets/styles/components/_status.scss
@@ -113,16 +113,6 @@
   .status {
     --ds-status-withBackground-bg-disabled: var(--grey-50);
     --ds-status-circle-bg-warning: var(--yellow-100);
-
-    &__circle--primary {
-      background-color: var(--grey-50);
-    }
-
-    &__withBackground {
-      background-color: inherit;
-    }
-
-
     --ds-status-circle-bg-primary: var(--grey-100);
     --ds-status-circle-bg-information: var(--blue-600);
     --ds-status-circle-bg-brand: var(--brand-500);
@@ -131,6 +121,14 @@
     --ds-status-circle-bg-success: var(--green-600);
     --ds-status-circle-bg-discovery: var(--purple-800);
     --ds-status-circle-bg-disabled: var(--grey-30);
+
+    &__circle--primary {
+      background-color: var(--grey-50);
+    }
+
+    &__withBackground {
+      background-color: inherit;
+    }
 
     &__withBackground--disabled {
       border-color: var(--grey-50);


### PR DESCRIPTION
Quote color-name map keys in _line-chart.scss to prevent interpolation of CSS color values, and move custom property declarations above nested rules in _status.scss to fix mixed-decls ordering.